### PR TITLE
Include main content area

### DIFF
--- a/templates/archives.html
+++ b/templates/archives.html
@@ -4,9 +4,8 @@
   {{ SITENAME }} - Archives
 {% endblock %}
 
-{% block content %}
+{% block maincontent %}
   {{ super() }}
-
   <div id="archives" class="pure-u-4-5">
     {% block archives %}
       <h1>Archives</h1>

--- a/templates/article.html
+++ b/templates/article.html
@@ -4,9 +4,8 @@
   {{ SITENAME }} - {{ article.title }}
 {% endblock %}
 
-{% block content %}   
+{% block maincontent %}   
   {{ super() }}
-
   {% block article %}
     <div id="article" class="pure-u-4-5">
       {% block article_title %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -36,6 +36,10 @@
               {% include 'chunk/categories-list.html' %}
             </div>
           {% endblock %}
+          <main id="main" tabindex="-1">
+            {% block maincontent %}
+            {% endblock %}
+          </main>
         {% endblock %}
       </div>
     </body>

--- a/templates/category.html
+++ b/templates/category.html
@@ -4,9 +4,8 @@
   {{ SITENAME }} - {{ category}}
 {% endblock %}
 
-{% block content %}
+{% block maincontent %}
   {{ super() }}
-
   <div id="articles-in-category" class="pure-u-4-5">
     <h2 class="page_title">
       Articles in category «{{ category }}»

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,9 +4,8 @@
   {{ SITENAME }}
 {% endblock %}
 
-{% block content %}
+{% block maincontent %}
   {{ super() }}
-
   {% block articles_index %}
     <div id="articles-index" class="pure-u-4-5">
       {% include 'chunk/articles-index.html' %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -4,7 +4,7 @@
   {{ page.title }}
 {% endblock %}
 
-{% block content %}        
+{% block maincontent %}        
   <h2 class="page_title">
     <a href="{{ SITEURL }}/{{ page.url }}">
       {{ page.title }}

--- a/templates/tag.html
+++ b/templates/tag.html
@@ -4,9 +4,8 @@
   {{ SITENAME }} - «{{ tag }}»
 {% endblock %}
 
-{% block content %}
+{% block maincontent %}
   {{ super() }}
-
   <div id="tags-list" class="pure-u-4-5">
     <h2 class="page_title">
       Articles with tag «{{ tag }}»

--- a/templates/tags.html
+++ b/templates/tags.html
@@ -4,9 +4,8 @@
   {{ SITENAME }} - List of Tags
 {% endblock %}
 
-{% block content %}
+{% block maincontent %}
   {{ super() }}
-
   {% block tags_index %}
     <div id="tags-index" class="pure-u-4-5">
       <h2 class="page_title">


### PR DESCRIPTION
Add `<mainn>`in `base.html`, add an empty block `maincontent`inside and
replace `content` with `maincontent`. This allows other templates to
include their data in this area, enhancing accessibility.

Maybe `{{super()}}` could be kept, but I'm not sure, so I removed it. It wouldn't serve any purpose, anyway.
