### PR TITLE
Replaced symbols in pagination with text

### DIFF
--- a/templates/chunk/articles-pagination.html
+++ b/templates/chunk/articles-pagination.html
@@ -2,14 +2,14 @@
   <nav class="pagination">
   {% if articles_page.has_previous() %}
     {% if articles_page.previous_page_number() == 1 %}
-      <a href="{{ SITEURL }}/{{ page_name }}.html">&#60;&#60;</a>
+      <a href="{{ SITEURL }}/{{ page_name }}.html">Prev</a>
     {% else %}
-      <a href="{{ SITEURL }}/{{ page_name }}{{ articles_page.previous_page_number() }}.html">&#60;&#60;</a>
+      <a href="{{ SITEURL }}/{{ page_name }}{{ articles_page.previous_page_number() }}.html">Prev</a>
     {% endif %}
   {% endif %}
   Page <b>{{ articles_page.number }}</b> of <b>{{ articles_paginator.num_pages }}</b>
   {% if articles_page.has_next() %}
-    <a href="{{ SITEURL }}/{{ page_name }}{{ articles_page.next_page_number() }}.html">&#62;&#62;</a>
+    <a href="{{ SITEURL }}/{{ page_name }}{{ articles_page.next_page_number() }}.html">Next</a>
   {% endif %}
   </nav>
 {% endif%}


### PR DESCRIPTION
This once again improves accessibility, as some screen readers wouldn't be
able to interpret the symbols correctly.
Fixes #8
